### PR TITLE
Update composer-local.json to add 3 CampaignSuite plug-ins

### DIFF
--- a/composer-local.json
+++ b/composer-local.json
@@ -10,9 +10,18 @@
   "scripts": {
     "core:language": "wp language core install nl_NL; wp language core activate nl_NL",
     "install:plugin-yoast": "wp plugin install --activate https://storage.googleapis.com/planet4-3rdparty-plugins/wordpress-seo-premium-23.9.zip",
+    "install:pluging-cs-core":"wp plugin install --activate https://update-v1.campaignsuite.nl/core/campaignsuite-core-1.7.20.zip",
+    "install:pluging-cs-forms":"wp plugin install --activate https://update-v1.campaignsuite.nl/forms/campaignsuite-forms-1.13.0.zip",
+    "install:pluging-cs-gp":"wp plugin install --activate https://update-v1.campaignsuite.nl/greenpeace/campaignsuite-greenpeace-addon.zip",
+    "install:campaignsuite":[
+      "@install:pluging-cs-core",
+      "@install:pluging-cs-forms",
+      "@install:pluging-cs-gp"
+    ],
     "site:custom": [
       "@core:language",
-      "@install:plugin-yoast"
+      "@install:plugin-yoast",
+      "@install:campaignsuite"
     ]
   }
 }


### PR DESCRIPTION
As discussed in Slack with Claudia, Greenpeace would need 3 plug-ins to run CampaignSuite. I added the files to a server so they can be accessed like this